### PR TITLE
Greedy scenario minimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__
 build
+build-cmake
 venv
 .devcontainer/**
 .cache/**

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -7,6 +7,7 @@ set (SOURCE_FILES
         scheduler.cpp
         verifying.cpp 
         generators.cpp
+        minimization.cpp
 )
 
 add_library(runtime STATIC ${SOURCE_FILES})

--- a/runtime/include/lib.h
+++ b/runtime/include/lib.h
@@ -85,6 +85,9 @@ struct CoroBase : public std::enable_shared_from_this<CoroBase> {
   // Sets the token.
   void SetToken(std::shared_ptr<Token>);
 
+  // Sets IsRemoved state.
+  void SetRemoved(bool is_removed);
+
   // Checks if the coroutine is parked.
   bool IsParked() const;
 

--- a/runtime/include/minimization.h
+++ b/runtime/include/minimization.h
@@ -82,7 +82,7 @@ struct GreedyRoundMinimizor : public RoundMinimizor {
   ) const = 0;
 };
 
-struct InterleavingMinimizor : public GreedyRoundMinimizor {
+struct SameInterleavingMinimizor : public GreedyRoundMinimizor {
   Scheduler::Result onSingleTaskRemoved(
     StrategyScheduler& sched,
     const Scheduler::Histories& nonlinear_history,
@@ -103,9 +103,9 @@ struct InterleavingMinimizor : public GreedyRoundMinimizor {
   }
 };
 
-struct StrategyMinimizor : public GreedyRoundMinimizor {
-  StrategyMinimizor() = delete;
-  explicit StrategyMinimizor(int runs_): runs(runs_) {}
+struct StrategyExplorationMinimizor : public GreedyRoundMinimizor {
+  StrategyExplorationMinimizor() = delete;
+  explicit StrategyExplorationMinimizor(int runs_): runs(runs_) {}
 
   Scheduler::Result onSingleTaskRemoved(
     StrategyScheduler& sched,

--- a/runtime/include/minimization.h
+++ b/runtime/include/minimization.h
@@ -2,60 +2,144 @@
 #include "lib.h"
 
 struct RoundMinimizor {
-    virtual Scheduler::Result onSingleTaskRemoved(StrategyScheduler* sched, const Scheduler::Histories& nonlinear_history, const Task& task) const = 0;
-
-    virtual Scheduler::Result onTwoTasksRemoved(StrategyScheduler* sched, const Scheduler::Histories& nonlinear_history, const Task& task_i, const Task& task_j) const = 0;
+  // Minimizes number of tasks in the nonlinearized history; modifies argument `nonlinear_history`.
+  virtual void minimize(
+    StrategyScheduler& sched,
+    Scheduler::Histories& nonlinear_history
+  ) const = 0;
 };
 
-struct InterleavingMinimizor : public RoundMinimizor {
-    Scheduler::Result onSingleTaskRemoved(
-        StrategyScheduler* sched,
-        const Scheduler::Histories& nonlinear_history,
-        const Task& task
-    ) const override {
-        std::vector<int> new_ordering = sched->getTasksOrdering(nonlinear_history.first, { task->GetId() });
-        return sched->replayRound(new_ordering);
+struct GreedyRoundMinimizor : public RoundMinimizor {
+  void minimize(
+    StrategyScheduler& sched,
+    Scheduler::Histories& nonlinear_history
+  ) const override {
+    std::vector<std::reference_wrapper<const Task>> tasks;
+
+    for (const HistoryEvent& event : nonlinear_history.second) {
+      if (std::holds_alternative<Invoke>(event)) {
+        tasks.push_back(std::get<Invoke>(event).GetTask());
+      }
     }
 
-    Scheduler::Result onTwoTasksRemoved(
-        StrategyScheduler* sched,
-        const Scheduler::Histories& nonlinear_history,
-        const Task& task_i,
-        const Task& task_j
-    ) const override {
-        std::vector<int> new_ordering = sched->getTasksOrdering(nonlinear_history.first, { task_i->GetId(), task_j->GetId() });
-        return sched->replayRound(new_ordering);
+    // remove single task
+    for (auto& task : tasks) {
+      if (task.get()->IsRemoved()) continue;
+
+      // log() << "Try to remove task with id: " << task.get()->GetId() << "\n";
+      auto new_histories = onSingleTaskRemoved(sched, nonlinear_history, task.get());
+
+      if (new_histories.has_value()) {
+        nonlinear_history.first.swap(new_histories.value().first);
+        nonlinear_history.second.swap(new_histories.value().second);
+        task.get()->SetRemoved(true);
+      }
     }
+
+    // remove two tasks (for operations with semantics of add/remove)
+    for (size_t i = 0; i < tasks.size(); ++i) {
+      auto& task_i = tasks[i];
+      if (task_i.get()->IsRemoved()) continue;
+      
+      for (size_t j = i + 1; j < tasks.size(); ++j) {
+        auto& task_j = tasks[j];
+        if (task_j.get()->IsRemoved()) continue;
+        
+        // log() << "Try to remove tasks with ids: " << task_i.get()->GetId() << " and "
+        //       << task_j.get()->GetId() << "\n";
+        auto new_histories = onTwoTasksRemoved(sched, nonlinear_history, task_i.get(), task_j.get());
+
+        if (new_histories.has_value()) {
+          // sequential history (Invoke/Response events) must have even number of history events
+          assert(new_histories.value().second.size() % 2 == 0);
+
+          nonlinear_history.first.swap(new_histories.value().first);
+          nonlinear_history.second.swap(new_histories.value().second);
+
+          task_i.get()->SetRemoved(true);
+          task_j.get()->SetRemoved(true);
+          break; // tasks (i, j) were removed, so go to the next iteration of i
+        }
+      }
+    }
+
+    // replay minimized round one last time to put coroutines in `returned` state
+    // (because multiple failed attempts to minimize new scenarios could leave tasks in invalid state)
+    sched.replayRound(StrategyScheduler::getTasksOrdering(nonlinear_history.first, {}));
+  };
+
+  virtual Scheduler::Result onSingleTaskRemoved(
+    StrategyScheduler& sched,
+    const Scheduler::Histories& nonlinear_history,
+    const Task& task
+  ) const = 0;
+
+  virtual Scheduler::Result onTwoTasksRemoved(
+    StrategyScheduler& sched,
+    const Scheduler::Histories& nonlinear_history,
+    const Task& task_i,
+    const Task& task_j
+  ) const = 0;
 };
 
-struct StrategyMinimizor : public RoundMinimizor {
-    StrategyMinimizor() = delete;
-    explicit StrategyMinimizor(int runs_): runs(runs_) {}
+struct InterleavingMinimizor : public GreedyRoundMinimizor {
+  Scheduler::Result onSingleTaskRemoved(
+    StrategyScheduler& sched,
+    const Scheduler::Histories& nonlinear_history,
+    const Task& task
+  ) const override {
+    std::vector<int> new_ordering = StrategyScheduler::getTasksOrdering(nonlinear_history.first, { task->GetId() });
+    return sched.replayRound(new_ordering);
+  }
 
-    Scheduler::Result onSingleTaskRemoved(StrategyScheduler* sched, const Scheduler::Histories& nonlinear_history, const Task& task) const override {
-        task->SetRemoved(true);
-        Scheduler::Result new_histories = sched->exploreRound(runs);
+  Scheduler::Result onTwoTasksRemoved(
+    StrategyScheduler& sched,
+    const Scheduler::Histories& nonlinear_history,
+    const Task& task_i,
+    const Task& task_j
+  ) const override {
+    std::vector<int> new_ordering = StrategyScheduler::getTasksOrdering(nonlinear_history.first, { task_i->GetId(), task_j->GetId() });
+    return sched.replayRound(new_ordering);
+  }
+};
 
-        if (!new_histories.has_value()) {
-        task->SetRemoved(false);
-        }
+struct StrategyMinimizor : public GreedyRoundMinimizor {
+  StrategyMinimizor() = delete;
+  explicit StrategyMinimizor(int runs_): runs(runs_) {}
 
-        return new_histories;
+  Scheduler::Result onSingleTaskRemoved(
+    StrategyScheduler& sched,
+    const Scheduler::Histories& nonlinear_history,
+    const Task& task
+  ) const override {
+    task->SetRemoved(true);
+    Scheduler::Result new_histories = sched.exploreRound(runs);
+
+    if (!new_histories.has_value()) {
+      task->SetRemoved(false);
     }
 
-    Scheduler::Result onTwoTasksRemoved(StrategyScheduler* sched, const Scheduler::Histories& nonlinear_history, const Task& task_i, const Task& task_j) const override {
-        task_i->SetRemoved(true);
-        task_j->SetRemoved(true);
-        Scheduler::Result new_histories = sched->exploreRound(runs);
+    return new_histories;
+  }
 
-        if (!new_histories.has_value()) {
-        task_i->SetRemoved(false);
-        task_j->SetRemoved(false);
-        }
+  Scheduler::Result onTwoTasksRemoved(
+    StrategyScheduler& sched,
+    const Scheduler::Histories& nonlinear_history,
+    const Task& task_i,
+    const Task& task_j
+  ) const override {
+    task_i->SetRemoved(true);
+    task_j->SetRemoved(true);
+    Scheduler::Result new_histories = sched.exploreRound(runs);
 
-        return new_histories;
+    if (!new_histories.has_value()) {
+      task_i->SetRemoved(false);
+      task_j->SetRemoved(false);
     }
+
+    return new_histories;
+  }
 
 private:
-    int runs;
+  int runs;
 };

--- a/runtime/include/minimization.h
+++ b/runtime/include/minimization.h
@@ -1,0 +1,61 @@
+#include "scheduler.h"
+#include "lib.h"
+
+struct RoundMinimizor {
+    virtual Scheduler::Result onSingleTaskRemoved(StrategyScheduler* sched, const Scheduler::Histories& nonlinear_history, const Task& task) const = 0;
+
+    virtual Scheduler::Result onTwoTasksRemoved(StrategyScheduler* sched, const Scheduler::Histories& nonlinear_history, const Task& task_i, const Task& task_j) const = 0;
+};
+
+struct InterleavingMinimizor : public RoundMinimizor {
+    Scheduler::Result onSingleTaskRemoved(
+        StrategyScheduler* sched,
+        const Scheduler::Histories& nonlinear_history,
+        const Task& task
+    ) const override {
+        std::vector<int> new_ordering = sched->getTasksOrdering(nonlinear_history.first, { task->GetId() });
+        return sched->replayRound(new_ordering);
+    }
+
+    Scheduler::Result onTwoTasksRemoved(
+        StrategyScheduler* sched,
+        const Scheduler::Histories& nonlinear_history,
+        const Task& task_i,
+        const Task& task_j
+    ) const override {
+        std::vector<int> new_ordering = sched->getTasksOrdering(nonlinear_history.first, { task_i->GetId(), task_j->GetId() });
+        return sched->replayRound(new_ordering);
+    }
+};
+
+struct StrategyMinimizor : public RoundMinimizor {
+    StrategyMinimizor() = delete;
+    explicit StrategyMinimizor(int runs_): runs(runs_) {}
+
+    Scheduler::Result onSingleTaskRemoved(StrategyScheduler* sched, const Scheduler::Histories& nonlinear_history, const Task& task) const override {
+        task->SetRemoved(true);
+        Scheduler::Result new_histories = sched->exploreRound(runs);
+
+        if (!new_histories.has_value()) {
+        task->SetRemoved(false);
+        }
+
+        return new_histories;
+    }
+
+    Scheduler::Result onTwoTasksRemoved(StrategyScheduler* sched, const Scheduler::Histories& nonlinear_history, const Task& task_i, const Task& task_j) const override {
+        task_i->SetRemoved(true);
+        task_j->SetRemoved(true);
+        Scheduler::Result new_histories = sched->exploreRound(runs);
+
+        if (!new_histories.has_value()) {
+        task_i->SetRemoved(false);
+        task_j->SetRemoved(false);
+        }
+
+        return new_histories;
+    }
+
+private:
+    int runs;
+};

--- a/runtime/include/minimization.h
+++ b/runtime/include/minimization.h
@@ -17,6 +17,7 @@ struct GreedyRoundMinimizor : public RoundMinimizor {
     Scheduler::Histories& nonlinear_history
   ) const override;
 
+protected:
   virtual Scheduler::Result OnSingleTaskRemoved(
     StrategyScheduler& sched,
     const Scheduler::Histories& nonlinear_history,
@@ -32,6 +33,7 @@ struct GreedyRoundMinimizor : public RoundMinimizor {
 };
 
 struct SameInterleavingMinimizor : public GreedyRoundMinimizor {
+protected:
   Scheduler::Result OnSingleTaskRemoved(
     StrategyScheduler& sched,
     const Scheduler::Histories& nonlinear_history,
@@ -51,6 +53,7 @@ struct StrategyExplorationMinimizor : public GreedyRoundMinimizor {
 
   explicit StrategyExplorationMinimizor(int runs_);
 
+protected:
   Scheduler::Result OnSingleTaskRemoved(
     StrategyScheduler& sched,
     const Scheduler::Histories& nonlinear_history,

--- a/runtime/include/minimization.h
+++ b/runtime/include/minimization.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "scheduler.h"
 #include "lib.h"
 
@@ -13,60 +15,7 @@ struct GreedyRoundMinimizor : public RoundMinimizor {
   void Minimize(
     StrategyScheduler& sched,
     Scheduler::Histories& nonlinear_history
-  ) const override {
-    std::vector<std::reference_wrapper<const Task>> tasks;
-
-    for (const HistoryEvent& event : nonlinear_history.second) {
-      if (std::holds_alternative<Invoke>(event)) {
-        tasks.push_back(std::get<Invoke>(event).GetTask());
-      }
-    }
-
-    // remove single task
-    for (auto& task : tasks) {
-      if (task.get()->IsRemoved()) continue;
-
-      // log() << "Try to remove task with id: " << task.get()->GetId() << "\n";
-      auto new_histories = OnSingleTaskRemoved(sched, nonlinear_history, task.get());
-
-      if (new_histories.has_value()) {
-        nonlinear_history.first.swap(new_histories.value().first);
-        nonlinear_history.second.swap(new_histories.value().second);
-        task.get()->SetRemoved(true);
-      }
-    }
-
-    // remove two tasks (for operations with semantics of add/remove)
-    for (size_t i = 0; i < tasks.size(); ++i) {
-      auto& task_i = tasks[i];
-      if (task_i.get()->IsRemoved()) continue;
-      
-      for (size_t j = i + 1; j < tasks.size(); ++j) {
-        auto& task_j = tasks[j];
-        if (task_j.get()->IsRemoved()) continue;
-        
-        // log() << "Try to remove tasks with ids: " << task_i.get()->GetId() << " and "
-        //       << task_j.get()->GetId() << "\n";
-        auto new_histories = OnTwoTasksRemoved(sched, nonlinear_history, task_i.get(), task_j.get());
-
-        if (new_histories.has_value()) {
-          // sequential history (Invoke/Response events) must have even number of history events
-          assert(new_histories.value().second.size() % 2 == 0);
-
-          nonlinear_history.first.swap(new_histories.value().first);
-          nonlinear_history.second.swap(new_histories.value().second);
-
-          task_i.get()->SetRemoved(true);
-          task_j.get()->SetRemoved(true);
-          break; // tasks (i, j) were removed, so go to the next iteration of i
-        }
-      }
-    }
-
-    // replay minimized round one last time to put coroutines in `returned` state
-    // (because multiple failed attempts to minimize new scenarios could leave tasks in invalid state)
-    sched.ReplayRound(StrategyScheduler::GetTasksOrdering(nonlinear_history.first, {}));
-  };
+  ) const override;
 
   virtual Scheduler::Result OnSingleTaskRemoved(
     StrategyScheduler& sched,
@@ -87,58 +36,33 @@ struct SameInterleavingMinimizor : public GreedyRoundMinimizor {
     StrategyScheduler& sched,
     const Scheduler::Histories& nonlinear_history,
     const Task& task
-  ) const override {
-    std::vector<int> new_ordering = StrategyScheduler::GetTasksOrdering(nonlinear_history.first, { task->GetId() });
-    return sched.ReplayRound(new_ordering);
-  }
+  ) const override;
 
   Scheduler::Result OnTwoTasksRemoved(
     StrategyScheduler& sched,
     const Scheduler::Histories& nonlinear_history,
     const Task& task_i,
     const Task& task_j
-  ) const override {
-    std::vector<int> new_ordering = StrategyScheduler::GetTasksOrdering(nonlinear_history.first, { task_i->GetId(), task_j->GetId() });
-    return sched.ReplayRound(new_ordering);
-  }
+  ) const override;
 };
 
 struct StrategyExplorationMinimizor : public GreedyRoundMinimizor {
   StrategyExplorationMinimizor() = delete;
-  explicit StrategyExplorationMinimizor(int runs_): runs(runs_) {}
+
+  explicit StrategyExplorationMinimizor(int runs_);
 
   Scheduler::Result OnSingleTaskRemoved(
     StrategyScheduler& sched,
     const Scheduler::Histories& nonlinear_history,
     const Task& task
-  ) const override {
-    task->SetRemoved(true);
-    Scheduler::Result new_histories = sched.ExploreRound(runs);
-
-    if (!new_histories.has_value()) {
-      task->SetRemoved(false);
-    }
-
-    return new_histories;
-  }
+  ) const override;
 
   Scheduler::Result OnTwoTasksRemoved(
     StrategyScheduler& sched,
     const Scheduler::Histories& nonlinear_history,
     const Task& task_i,
     const Task& task_j
-  ) const override {
-    task_i->SetRemoved(true);
-    task_j->SetRemoved(true);
-    Scheduler::Result new_histories = sched.ExploreRound(runs);
-
-    if (!new_histories.has_value()) {
-      task_i->SetRemoved(false);
-      task_j->SetRemoved(false);
-    }
-
-    return new_histories;
-  }
+  ) const override;
 
 private:
   int runs;

--- a/runtime/include/pct_strategy.h
+++ b/runtime/include/pct_strategy.h
@@ -141,6 +141,7 @@ struct PctStrategy : Strategy {
   }
 
   void StartNextRound() override {
+    next_task_id = 0;
     //    log() << "depth: " << current_depth << "\n";
     // Reconstruct target as we start from the beginning.
     TerminateTasks();

--- a/runtime/include/pct_strategy.h
+++ b/runtime/include/pct_strategy.h
@@ -177,7 +177,9 @@ struct PctStrategy : Strategy {
     for (auto& thread : threads) {
       size_t tasks_in_thread = thread.size();
       for (size_t i = 0; i < tasks_in_thread; ++i) {
-        thread[i] = thread[i]->Restart(&state);
+        if (!thread[i]->IsRemoved()) {
+          thread[i] = thread[i]->Restart(&state);
+        }
       }
     }
   }
@@ -220,8 +222,10 @@ struct PctStrategy : Strategy {
 
   void TerminateTasks() {
     for (auto& thread : threads) {
-      if (!thread.empty()) {
-        thread.back()->Terminate();
+      for (size_t i = 0; i < thread.size(); ++i) {
+        if (!thread[i]->IsReturned()) {
+          thread[i]->Terminate();
+        }
       }
     }
   }

--- a/runtime/include/pct_strategy.h
+++ b/runtime/include/pct_strategy.h
@@ -114,7 +114,7 @@ struct PctStrategy : Strategy {
       }
 
       threads[index_of_max].emplace_back(
-          constructor.Build(&state, index_of_max));
+          constructor.Build(&state, index_of_max, next_task_id++));
       return {threads[index_of_max].back(), true, index_of_max};
     }
 

--- a/runtime/include/pct_strategy.h
+++ b/runtime/include/pct_strategy.h
@@ -121,6 +121,25 @@ struct PctStrategy : Strategy {
     return {threads[index_of_max].back(), false, index_of_max};
   }
 
+  std::optional<std::tuple<Task&, int>> GetTask(int task_id) override {
+    // TODO: can this be optimized?
+    int thread_id = 0;
+    for (auto& thread : threads) {
+      size_t tasks = thread.size();
+
+      for (size_t i = 0; i < tasks; ++i) {
+        Task& task = thread[i];
+        if (task->GetId() == task_id) {
+          std::tuple<Task&, int> result = { task, thread_id };
+          return result;
+        }
+      }
+
+      thread_id++;
+    }
+    return std::nullopt;
+  }
+
   void StartNextRound() override {
     //    log() << "depth: " << current_depth << "\n";
     // Reconstruct target as we start from the beginning.
@@ -149,6 +168,17 @@ struct PctStrategy : Strategy {
 
     for (auto& thread : threads) {
       thread = StableVector<Task>();
+    }
+  }
+
+  void ResetCurrentRound() override {
+    TerminateTasks();
+    state.Reset();
+    for (auto& thread : threads) {
+      size_t tasks_in_thread = thread.size();
+      for (size_t i = 0; i < tasks_in_thread; ++i) {
+        thread[i] = thread[i]->Restart(&state);
+      }
     }
   }
 

--- a/runtime/include/pct_strategy.h
+++ b/runtime/include/pct_strategy.h
@@ -22,6 +22,8 @@ struct PctStrategy : Strategy {
         constructors(constructors),
         threads(),
         is_another_required(is_another_required) {
+    round_schedule.resize(threads_count, -1);
+
     std::random_device dev;
     rng = std::mt19937(dev());
     constructors_distribution =
@@ -114,11 +116,15 @@ struct PctStrategy : Strategy {
       }
 
       threads[index_of_max].emplace_back(
-          constructor.Build(&state, index_of_max, next_task_id++));
+          constructor.Build(&state, index_of_max, new_task_id++));
       return {threads[index_of_max].back(), true, index_of_max};
     }
 
     return {threads[index_of_max].back(), false, index_of_max};
+  }
+
+  std::tuple<Task&, bool, int> NextSchedule() override {
+    assert(false && "unimplemented");
   }
 
   std::optional<std::tuple<Task&, int>> GetTask(int task_id) override {
@@ -141,7 +147,8 @@ struct PctStrategy : Strategy {
   }
 
   void StartNextRound() override {
-    next_task_id = 0;
+    new_task_id = 0;
+
     //    log() << "depth: " << current_depth << "\n";
     // Reconstruct target as we start from the beginning.
     TerminateTasks();
@@ -175,6 +182,7 @@ struct PctStrategy : Strategy {
   void ResetCurrentRound() override {
     TerminateTasks();
     state.Reset();
+
     for (auto& thread : threads) {
       size_t tasks_in_thread = thread.size();
       for (size_t i = 0; i < tasks_in_thread; ++i) {
@@ -185,9 +193,41 @@ struct PctStrategy : Strategy {
     }
   }
 
+  int GetValidTasksCount() const override {
+    int non_removed_tasks = 0;
+    for (auto& thread : threads) {
+      for (size_t i = 0; i < thread.size(); ++i) {
+        auto& task = thread[i];
+        if (!task.get()->IsRemoved()) {
+          non_removed_tasks++;
+        }
+      }
+    }
+    return non_removed_tasks;
+  }
+
   ~PctStrategy() { TerminateTasks(); }
 
- private:
+protected:
+  int GetNextTaskInThread(int thread_index) const override {
+    auto& thread = threads[thread_index];
+    int task_index = round_schedule[thread_index];
+
+    while (
+      task_index < static_cast<int>(thread.size()) &&
+      (
+        task_index == -1 ||
+        thread[task_index].get()->IsReturned() ||
+        thread[task_index].get()->IsRemoved()
+      )
+    ) {
+      task_index++;
+    }
+
+    return task_index;
+  }
+
+private:
   std::unordered_set<std::string> CountNames(size_t except_thread) {
     std::unordered_set<std::string> names;
 
@@ -222,6 +262,9 @@ struct PctStrategy : Strategy {
   }
 
   void TerminateTasks() {
+    assert(round_schedule.size() == threads.size() && "sizes expected to be the same");
+    round_schedule.assign(round_schedule.size(), -1);
+
     for (auto& thread : threads) {
       for (size_t i = 0; i < thread.size(); ++i) {
         if (!thread[i]->IsReturned()) {

--- a/runtime/include/pick_strategy.h
+++ b/runtime/include/pick_strategy.h
@@ -67,6 +67,8 @@ struct PickStrategy : Strategy {
   }
 
   void StartNextRound() override {
+    next_task_id = 0;
+
     TerminateTasks();
     for (auto& thread : threads) {
       // We don't have to keep references alive

--- a/runtime/include/pick_strategy.h
+++ b/runtime/include/pick_strategy.h
@@ -6,7 +6,7 @@
 #include "scheduler.h"
 
 template <typename TargetObj>
-struct PickStrategy : Strategy {
+struct PickStrategy : public BaseStrategyWithThreads<TargetObj> {
   virtual size_t Pick() = 0;
 
   virtual size_t PickSchedule() = 0;
@@ -14,34 +14,34 @@ struct PickStrategy : Strategy {
   explicit PickStrategy(size_t threads_count,
                         std::vector<TaskBuilder> constructors)
       : next_task(0),
-        threads_count(threads_count),
-        constructors(std::move(constructors)),
-        threads() {
-    round_schedule.resize(threads_count, -1);
+        threads_count(threads_count) {
+    this->constructors = std::move(constructors);
+    Strategy::round_schedule.resize(threads_count, -1);
 
     std::random_device dev;
     rng = std::mt19937(dev());
-    distribution = std::uniform_int_distribution<std::mt19937::result_type>(
+    this->constructors_distribution = std::uniform_int_distribution<std::mt19937::result_type>(
         0, this->constructors.size() - 1);
 
     // Create queues.
     for (size_t i = 0; i < threads_count; ++i) {
-      threads.emplace_back();
+      this->threads.emplace_back();
     }
   }
 
   // If there aren't any non returned tasks and the amount of finished tasks
   // is equal to the max_tasks the finished task will be returned
   std::tuple<Task&, bool, int> Next() override {
+    auto& threads = this->threads;
     auto current_thread = Pick();
 
     // it's the first task if the queue is empty
     if (threads[current_thread].empty() ||
         threads[current_thread].back()->IsReturned()) {
       // a task has finished or the queue is empty, so we add a new task
-      auto constructor = constructors.at(distribution(rng));
+      auto constructor = this->constructors.at(this->constructors_distribution(rng));
       threads[current_thread].emplace_back(
-          constructor.Build(&state, current_thread, new_task_id++));
+          constructor.Build(&this->state, current_thread, Strategy::new_task_id++));
       return {threads[current_thread].back(), true, current_thread};
     }
 
@@ -49,40 +49,20 @@ struct PickStrategy : Strategy {
   }
 
   std::tuple<Task&, bool, int> NextSchedule() override {
+    auto& round_schedule = Strategy::round_schedule;
     size_t current_thread = PickSchedule();
-    int next_task_index = GetNextTaskInThread(current_thread);
+    int next_task_index = this->GetNextTaskInThread(current_thread);
     bool is_new = round_schedule[current_thread] != next_task_index;
 
     round_schedule[current_thread] = next_task_index;
-    return { threads[current_thread][next_task_index], is_new, current_thread };
-  }
-
-  // TODO: same implementation for pct
-  std::optional<std::tuple<Task&, int>> GetTask(int task_id) override {
-    // TODO: can this be optimized?
-    int thread_id = 0;
-    for (auto& thread : threads) {
-      size_t tasks = thread.size();
-
-      for (size_t i = 0; i < tasks; ++i) {
-        Task& task = thread[i];
-        if (task->GetId() == task_id) {
-          std::tuple<Task&, int> result = { task, thread_id };
-          return result;
-          // return std::make_tuple(task, thread_id);
-        }
-      }
-
-      thread_id++;
-    }
-    return std::nullopt;
+    return { this->threads[current_thread][next_task_index], is_new, current_thread };
   }
 
   void StartNextRound() override {
-    new_task_id = 0;
+    Strategy::new_task_id = 0;
 
-    TerminateTasks();
-    for (auto& thread : threads) {
+    this->TerminateTasks();
+    for (auto& thread : this->threads) {
       // We don't have to keep references alive
       while (thread.size() > 0) {
         thread.pop_back();
@@ -90,88 +70,15 @@ struct PickStrategy : Strategy {
     }
 
     // Reinitial target as we start from the beginning.
-    state.Reset();
+    this->state.Reset();
   }
 
-  // TODO: this method is identical for pick_strategy and for pct_strategy
-  void ResetCurrentRound() override {
-    TerminateTasks();
-    state.Reset();
-    for (auto& thread : threads) {
-      size_t tasks_in_thread = thread.size();
-      for (size_t i = 0; i < tasks_in_thread; ++i) {
-        if (!thread[i]->IsRemoved()) {
-          thread[i] = thread[i]->Restart(&state);
-        }
-      }
-    }
+  ~PickStrategy() {
+    this->TerminateTasks();
   }
-
-  // TODO: same implementation for pct
-  int GetValidTasksCount() const override {
-    int non_removed_tasks = 0;
-    for (auto& thread : threads) {
-      for (size_t i = 0; i < thread.size(); ++i) {
-        auto& task = thread[i];
-        if (!task.get()->IsRemoved()) {
-          non_removed_tasks++;
-        }
-      }
-    }
-    return non_removed_tasks;
-  }
-
-  ~PickStrategy() { TerminateTasks(); }
 
 protected:
-  // Terminates all running tasks.
-  // We do it in a dangerous way: in random order.
-  // Actually, we assume obstruction free here.
-  // TODO: for non obstruction-free we need to take into account dependencies.
-  void TerminateTasks() {
-    assert(round_schedule.size() == threads.size() && "sizes expected to be the same");
-    round_schedule.assign(round_schedule.size(), -1);
-
-    for (size_t i = 0; i < threads.size(); ++i) {      
-      for (size_t j = 0; j < threads[i].size(); ++j) {
-        auto& task = threads[i][j];
-        if (!task->IsReturned()) {
-          task->Terminate();
-        }
-      }
-    }
-  }
-
-  // TODO: same implementation for pct
-  int GetNextTaskInThread(int thread_index) const override {
-    auto& thread = threads[thread_index];
-    int task_index = round_schedule[thread_index];
-
-    while (
-      task_index < static_cast<int>(thread.size()) &&
-      (
-        task_index == -1 ||
-        thread[task_index].get()->IsReturned() ||
-        thread[task_index].get()->IsRemoved()
-      )
-    ) {
-      task_index++;
-    }
-
-    // TODO: we can update `round_schedule[thread_index] = task_index` here
-    // in order to optimize multiple calls to this function
-    return task_index;
-  }
-
-  TargetObj state{};
   size_t next_task = 0;
   size_t threads_count;
-  std::vector<TaskBuilder> constructors;
-  // RoundRobinStrategy struct is the owner of all tasks, and all
-  // references can't be invalidated before the end of the round,
-  // so we have to contains all tasks in queues(queue doesn't invalidate the
-  // references)
-  std::vector<StableVector<Task>> threads;
-  std::uniform_int_distribution<std::mt19937::result_type> distribution;
   std::mt19937 rng;
 };

--- a/runtime/include/pick_strategy.h
+++ b/runtime/include/pick_strategy.h
@@ -86,7 +86,9 @@ struct PickStrategy : Strategy {
     for (auto& thread : threads) {
       size_t tasks_in_thread = thread.size();
       for (size_t i = 0; i < tasks_in_thread; ++i) {
-        thread[i] = thread[i]->Restart(&state);
+        if (!thread[i]->IsRemoved()) {
+          thread[i] = thread[i]->Restart(&state);
+        }
       }
     }
   }
@@ -99,9 +101,12 @@ struct PickStrategy : Strategy {
   // Actually, we assume obstruction free here.
   // TODO: for non obstruction-free we need to take into account dependencies.
   void TerminateTasks() {
-    for (size_t i = 0; i < threads.size(); ++i) {
-      if (!threads[i].empty()) {
-        threads[i].back()->Terminate();
+    for (size_t i = 0; i < threads.size(); ++i) {      
+      for (size_t j = 0; j < threads[i].size(); ++j) {
+        auto& task = threads[i][j];
+        if (!task->IsReturned()) {
+          task->Terminate();
+        }
       }
     }
   }

--- a/runtime/include/pick_strategy.h
+++ b/runtime/include/pick_strategy.h
@@ -29,6 +29,7 @@ struct PickStrategy : Strategy {
   // If there aren't any non returned tasks and the amount of finished tasks
   // is equal to the max_tasks the finished task will be returned
   std::tuple<Task&, bool, int> Next() override {
+    // TODO: maybe `current_thread`?
     auto current_task = Pick();
 
     // it's the first task if the queue is empty
@@ -44,6 +45,27 @@ struct PickStrategy : Strategy {
     return {threads[current_task].back(), false, current_task};
   }
 
+  // TODO: same iplementation for pct
+  std::optional<std::tuple<Task&, int>> GetTask(int task_id) override {
+    // TODO: can this be optimized?
+    int thread_id = 0;
+    for (auto& thread : threads) {
+      size_t tasks = thread.size();
+
+      for (size_t i = 0; i < tasks; ++i) {
+        Task& task = thread[i];
+        if (task->GetId() == task_id) {
+          std::tuple<Task&, int> result = { task, thread_id };
+          return result;
+          // return std::make_tuple(task, thread_id);
+        }
+      }
+
+      thread_id++;
+    }
+    return std::nullopt;
+  }
+
   void StartNextRound() override {
     TerminateTasks();
     for (auto& thread : threads) {
@@ -55,6 +77,18 @@ struct PickStrategy : Strategy {
 
     // Reinitial target as we start from the beginning.
     state.Reset();
+  }
+
+  // TODO: this method is identical for pick_strategy and for pct_strategy
+  void ResetCurrentRound() override {
+    TerminateTasks();
+    state.Reset();
+    for (auto& thread : threads) {
+      size_t tasks_in_thread = thread.size();
+      for (size_t i = 0; i < tasks_in_thread; ++i) {
+        thread[i] = thread[i]->Restart(&state);
+      }
+    }
   }
 
   ~PickStrategy() { TerminateTasks(); }

--- a/runtime/include/pick_strategy.h
+++ b/runtime/include/pick_strategy.h
@@ -37,7 +37,7 @@ struct PickStrategy : Strategy {
       // a task has finished or the queue is empty, so we add a new task
       auto constructor = constructors.at(distribution(rng));
       threads[current_task].emplace_back(
-          constructor.Build(&state, current_task));
+          constructor.Build(&state, current_task, next_task_id++));
       return {threads[current_task].back(), true, current_task};
     }
 

--- a/runtime/include/pretty_print.h
+++ b/runtime/include/pretty_print.h
@@ -8,6 +8,7 @@
 
 #include "lib.h"
 #include "lincheck.h"
+#include "logger.h"
 
 using std::string;
 using std::to_string;
@@ -90,6 +91,7 @@ struct PrettyPrinter {
       if (i.index() == 0) {
         auto inv = get<0>(i);
         auto& task = inv.GetTask();
+        fp.Out("[" + std::to_string(task->GetId()) + "] ");
         fp.Out(std::string{task->GetName()});
         fp.Out("(");
         const auto& args = task->GetStrArgs();
@@ -174,7 +176,7 @@ struct PrettyPrinter {
         index[base] = sz;
       }
       int length = std::to_string(index[base]).size();
-      std::cout << index[base];
+      log() << index[base];
       assert(spaces - length >= 0);
       print_spaces(7 - length);
       int num = i.first;

--- a/runtime/include/random_strategy.h
+++ b/runtime/include/random_strategy.h
@@ -48,8 +48,7 @@ struct RandomStrategy : PickStrategy<TargetObj> {
     auto &threads = PickStrategy<TargetObj>::threads;
 
     for (size_t i = 0; i < threads.size(); ++i) {
-      int task_index = this->GetNextTaskInThread(i);      
-
+      int task_index = this->GetNextTaskInThread(i);
       if (
         task_index == threads[i].size() ||
         threads[i][task_index]->IsParked()

--- a/runtime/include/round_robin_strategy.h
+++ b/runtime/include/round_robin_strategy.h
@@ -26,7 +26,20 @@ struct RoundRobinStrategy : PickStrategy<TargetObj> {
   }
 
   size_t PickSchedule() override {
-    assert(false && "unimplemented");
+    auto &threads = PickStrategy<TargetObj>::threads;
+    for (size_t attempt = 0; attempt < threads.size(); ++attempt) {
+      auto cur = (next_task++) % threads.size();
+      int task_index = this->GetNextTaskInThread(cur);
+
+      if (
+        task_index == threads[cur].size() ||
+        threads[cur][task_index]->IsParked()
+      ) {
+        continue;
+      }
+      return cur;
+    }
+    assert(false && "deadlock");
   }
 
   size_t next_task;

--- a/runtime/include/round_robin_strategy.h
+++ b/runtime/include/round_robin_strategy.h
@@ -25,5 +25,9 @@ struct RoundRobinStrategy : PickStrategy<TargetObj> {
     assert(false && "deadlock");
   }
 
+  size_t PickSchedule() override {
+    assert(false && "unimplemented");
+  }
+
   size_t next_task;
 };

--- a/runtime/include/scheduler.h
+++ b/runtime/include/scheduler.h
@@ -170,8 +170,8 @@ struct StrategyScheduler : Scheduler {
   Result Run() override;
 
   friend class GreedyRoundMinimizor;
-  friend class InterleavingMinimizor;
-  friend class StrategyMinimizor;
+  friend class SameInterleavingMinimizor;
+  friend class StrategyExplorationMinimizor;
  private:
   // Runs a round with some interleaving while generating it
   Result runRound();

--- a/runtime/include/scheduler.h
+++ b/runtime/include/scheduler.h
@@ -174,17 +174,17 @@ struct StrategyScheduler : Scheduler {
   friend class StrategyExplorationMinimizor;
  private:
   // Runs a round with some interleaving while generating it
-  Result runRound();
+  Result RunRound();
 
   // Runs different interleavings of the current round
-  Result exploreRound(int runs);
+  Result ExploreRound(int runs);
 
   // Replays current round with specified interleaving
-  Result replayRound(const std::vector<int>& tasks_ordering);
+  Result ReplayRound(const std::vector<int>& tasks_ordering);
 
-  static std::vector<int> getTasksOrdering(const FullHistory& full_history, std::unordered_set<int> exclude_task_ids);
+  static std::vector<int> GetTasksOrdering(const FullHistory& full_history, std::unordered_set<int> exclude_task_ids);
 
-  void minimize(Scheduler::Histories& nonlinear_history, const RoundMinimizor& minimizor);
+  void Minimize(Scheduler::Histories& nonlinear_history, const RoundMinimizor& minimizor);
 
   Strategy& strategy;
 

--- a/runtime/include/scheduler.h
+++ b/runtime/include/scheduler.h
@@ -21,6 +21,9 @@ struct Strategy {
   virtual void StartNextRound() = 0;
 
   virtual ~Strategy() = default;
+
+protected:
+  int next_task_id = 0;
 };
 
 struct Scheduler {
@@ -29,6 +32,8 @@ struct Scheduler {
   using Result = std::optional<std::pair<FullHistory, SeqHistory>>;
 
   virtual Result Run() = 0;
+
+  // virtual Result minimizeHistory(Result nonlinear_history) = 0;
 
   virtual ~Scheduler() = default;
 };
@@ -49,6 +54,10 @@ struct StrategyScheduler : Scheduler {
 
  private:
   Result runRound();
+
+  // Result replayRound(FullHistory tasks_order);
+
+  // Result minimizeHistory(Result nonlinear_history);
 
   Strategy& strategy;
 
@@ -83,7 +92,7 @@ struct TLAScheduler : Scheduler {
 
   Result Run() override {
     auto [_, res] = RunStep(0, 0);
-    return res;
+    return res; 
   }
 
   ~TLAScheduler() { TerminateTasks(); }
@@ -254,7 +263,7 @@ struct TLAScheduler : Scheduler {
       for (size_t cons_num = 0; auto cons : constructors) {
         frame.is_new = true;
         auto size_before = tasks.size();
-        tasks.emplace_back(cons.Build(&state, i));
+        tasks.emplace_back(cons.Build(&state, i, -1 /* TODO: fix task id for tla, because it is Scheduler and not Strategy class for some reason */));
 
         auto [is_over, res] = ResumeTask(frame, step, switches, thread, true);
         if (is_over || res.has_value()) {

--- a/runtime/include/scheduler.h
+++ b/runtime/include/scheduler.h
@@ -17,8 +17,14 @@ struct Strategy {
   // the flag which tells is the task new, and the thread number.
   virtual std::tuple<Task&, bool, int> Next() = 0;
 
-  // Strategy should stop all tasks that already have been started
+  virtual std::optional<std::tuple<Task&, int>> GetTask(int task_id) = 0;
+
+  // Removes all tasks to start a new round.
+  // (Note: strategy should stop all tasks that already have been started)
   virtual void StartNextRound() = 0;
+
+  // Resets the state of all created tasks in the strategy.
+  virtual void ResetCurrentRound() = 0;
 
   virtual ~Strategy() = default;
 
@@ -55,7 +61,9 @@ struct StrategyScheduler : Scheduler {
  private:
   Result runRound();
 
-  // Result replayRound(FullHistory tasks_order);
+  Result replayRound(const std::vector<int>& tasks_ordering);
+
+  std::vector <int> getTasksOrdering(const FullHistory& full_history) const;
 
   // Result minimizeHistory(Result nonlinear_history);
 

--- a/runtime/include/scheduler.h
+++ b/runtime/include/scheduler.h
@@ -162,7 +162,7 @@ struct StrategyScheduler : Scheduler {
   // scheduler will end execution of the Run function
   StrategyScheduler(Strategy& sched_class, ModelChecker& checker,
                     PrettyPrinter& pretty_printer, size_t max_tasks,
-                    size_t max_rounds);
+                    size_t max_rounds, size_t minimization_runs);
 
   // Run returns full unliniarizable history if such a history is found. Full
   // history is a history with all events, where each element in the vector is a
@@ -195,6 +195,8 @@ struct StrategyScheduler : Scheduler {
   size_t max_tasks;
 
   size_t max_rounds;
+
+  size_t minimization_runs;
 };
 
 // TLAScheduler generates all executions satisfying some conditions.

--- a/runtime/include/scheduler.h
+++ b/runtime/include/scheduler.h
@@ -63,7 +63,9 @@ struct StrategyScheduler : Scheduler {
 
   Result replayRound(const std::vector<int>& tasks_ordering);
 
-  std::vector <int> getTasksOrdering(const FullHistory& full_history) const;
+  std::vector<int> getTasksOrdering(const FullHistory& full_history, std::unordered_set<int> exclude_task_ids) const;
+
+  void minimize(std::pair<Scheduler::FullHistory, Scheduler::SeqHistory>& nonlinear_history);
 
   // Result minimizeHistory(Result nonlinear_history);
 
@@ -136,8 +138,11 @@ struct TLAScheduler : Scheduler {
   // TODO: for non obstruction-free we need to take into account dependencies.
   void TerminateTasks() {
     for (size_t i = 0; i < threads.size(); ++i) {
-      if (!threads[i].tasks.empty()) {
-        threads[i].tasks.back()->Terminate();
+      for (size_t j = 0; j < threads[i].tasks.size(); ++j) {
+        auto& task = threads[i].tasks[j];
+        if (!task->IsReturned()) {
+          task->Terminate();
+        }
       }
     }
   }

--- a/runtime/include/scheduler.h
+++ b/runtime/include/scheduler.h
@@ -169,6 +169,7 @@ struct StrategyScheduler : Scheduler {
   // Resume operation on the corresponding task
   Result Run() override;
 
+  friend class GreedyRoundMinimizor;
   friend class InterleavingMinimizor;
   friend class StrategyMinimizor;
  private:
@@ -181,14 +182,9 @@ struct StrategyScheduler : Scheduler {
   // Replays current round with specified interleaving
   Result replayRound(const std::vector<int>& tasks_ordering);
 
-  std::vector<int> getTasksOrdering(const FullHistory& full_history, std::unordered_set<int> exclude_task_ids) const;
+  static std::vector<int> getTasksOrdering(const FullHistory& full_history, std::unordered_set<int> exclude_task_ids);
 
-  // Minimizes number of tasks in the nonlinearized history preserving threads interleaving.
-  // Modifies argument `nonlinear_history`.
-  void minimize(
-    Histories& nonlinear_history,
-    const RoundMinimizor& minimizor
-  );
+  void minimize(Scheduler::Histories& nonlinear_history, const RoundMinimizor& minimizor);
 
   Strategy& strategy;
 

--- a/runtime/include/scheduler.h
+++ b/runtime/include/scheduler.h
@@ -13,10 +13,14 @@
 // will be the next one it can be implemented by different strategies, such as:
 // randomized/tla/fair
 struct Strategy {
-  // Returns the next tasks,
-  // the flag which tells is the task new, and the thread number.
+  // Returns { next task, the flag which tells is the task new, thread number }.
   virtual std::tuple<Task&, bool, int> Next() = 0;
 
+  // Returns the same data as `Next` method. However, it does not generate the round,
+  // but schedules the threads accoding to the strategy policy 
+  virtual std::tuple<Task&, bool, int> NextSchedule() = 0;
+
+  // Returns { task, its thread id }
   virtual std::optional<std::tuple<Task&, int>> GetTask(int task_id) = 0;
 
   // Removes all tasks to start a new round.
@@ -26,25 +30,36 @@ struct Strategy {
   // Resets the state of all created tasks in the strategy.
   virtual void ResetCurrentRound() = 0;
 
+  // Returns the number of non-removed tasks
+  virtual int GetValidTasksCount() const = 0;
+
   virtual ~Strategy() = default;
 
 protected:
-  int next_task_id = 0;
+  // For current round returns first task index in thread which is greater
+  // than `round_schedule[thread]` or the same index if the task is not finished
+  virtual int GetNextTaskInThread(int thread_index) const = 0;
+
+
+  // id of next generated task
+  int new_task_id = 0;
+  // when generated round is explored this vector stores indexes of tasks
+  // that will be invoked next in each thread
+  std::vector<int> round_schedule;
 };
 
 struct Scheduler {
   using FullHistory = std::vector<std::reference_wrapper<Task>>;
   using SeqHistory = std::vector<std::variant<Invoke, Response>>;
-  using Result = std::optional<std::pair<FullHistory, SeqHistory>>;
+  using Histories = std::pair<FullHistory, SeqHistory>;
+  using Result = std::optional<Histories>;
 
   virtual Result Run() = 0;
-
-  // virtual Result minimizeHistory(Result nonlinear_history) = 0;
 
   virtual ~Scheduler() = default;
 };
 
-// StrategyScheduler generates different sequential histories(using Strategy)
+// StrategyScheduler generates different sequential histories (using Strategy)
 // and then checks them with the ModelChecker
 struct StrategyScheduler : Scheduler {
   // max_switches represents the maximal count of switches. After this count
@@ -59,15 +74,31 @@ struct StrategyScheduler : Scheduler {
   Result Run() override;
 
  private:
+  // Runs a round with some interleaving while generating it
   Result runRound();
 
+  // Runs different interleavings of the current round
+  Result exploreRound(int max_runs);
+
+  // Replays current round with specified interleaving
   Result replayRound(const std::vector<int>& tasks_ordering);
 
   std::vector<int> getTasksOrdering(const FullHistory& full_history, std::unordered_set<int> exclude_task_ids) const;
 
-  void minimize(std::pair<Scheduler::FullHistory, Scheduler::SeqHistory>& nonlinear_history);
+  using SingleTaskRemovedCallback = Result (*)(StrategyScheduler*, const Histories&, const Task&);
+  using TwoTasksRemovedCallback = Result (*)(StrategyScheduler*, const Histories&, const Task&, const Task&);
 
-  // Result minimizeHistory(Result nonlinear_history);
+  // Minimizes number of tasks in the nonlinearized history preserving threads interleaving.
+  // Modifies argument `nonlinear_history`.
+  void minimize(
+    Histories& nonlinear_history,
+    SingleTaskRemovedCallback,
+    TwoTasksRemovedCallback
+  );
+
+  void minimizeSameInterleaving(Histories& nonlinear_history);
+
+  void minimizeWithStrategy(Histories& nonlinear_history);
 
   Strategy& strategy;
 

--- a/runtime/include/verifying.h
+++ b/runtime/include/verifying.h
@@ -33,6 +33,7 @@ struct Opts {
   size_t tasks;
   size_t switches;
   size_t rounds;
+  size_t minimization_runs;
   bool verbose;
   StrategyType typ;
   std::vector<int> thread_weights;
@@ -78,10 +79,10 @@ std::unique_ptr<Strategy> MakeStrategy(Opts &opts, std::vector<TaskBuilder> l) {
 struct StrategySchedulerWrapper : StrategyScheduler {
   StrategySchedulerWrapper(std::unique_ptr<Strategy> strategy,
                            ModelChecker &checker, PrettyPrinter &pretty_printer,
-                           size_t max_tasks, size_t max_rounds)
+                           size_t max_tasks, size_t max_rounds, size_t minimization_runs)
       : strategy(std::move(strategy)),
         StrategyScheduler(*strategy.get(), checker, pretty_printer, max_tasks,
-                          max_rounds) {};
+                          max_rounds, minimization_runs) {};
 
  private:
   std::unique_ptr<Strategy> strategy;
@@ -99,7 +100,7 @@ std::unique_ptr<Scheduler> MakeScheduler(ModelChecker &checker, Opts &opts,
       auto strategy = MakeStrategy<TargetObj>(opts, std::move(l));
       auto scheduler = std::make_unique<StrategySchedulerWrapper>(
           std::move(strategy), checker, pretty_printer, opts.tasks,
-          opts.rounds);
+          opts.rounds, opts.minimization_runs);
       return scheduler;
     }
     case TLA: {
@@ -123,6 +124,7 @@ int Run(int argc, char *argv[]) {
   std::cout << "tasks    = " << opts.tasks << "\n";
   std::cout << "switches = " << opts.switches << "\n";
   std::cout << "rounds   = " << opts.rounds << "\n";
+  std::cout << "minimization runs   = " << opts.minimization_runs << "\n";
   std::cout << "targets  = " << task_builders.size() << "\n";
 
   PrettyPrinter pretty_printer{opts.threads};

--- a/runtime/include/verifying.h
+++ b/runtime/include/verifying.h
@@ -69,7 +69,7 @@ std::unique_ptr<Strategy> MakeStrategy(Opts &opts, std::vector<TaskBuilder> l) {
                                                       std::move(l), true);
     }
     default:
-      assert(false && "unexpected typ");
+      assert(false && "unexpected type");
   }
 }
 

--- a/runtime/include/verifying.h
+++ b/runtime/include/verifying.h
@@ -103,6 +103,7 @@ std::unique_ptr<Scheduler> MakeScheduler(ModelChecker &checker, Opts &opts,
       return scheduler;
     }
     case TLA: {
+      std::cout << "tla\n";
       auto scheduler = std::make_unique<TLAScheduler<TargetObj>>(
           opts.tasks, opts.rounds, opts.threads, opts.switches, std::move(l),
           checker, pretty_printer);
@@ -117,6 +118,7 @@ int Run(int argc, char *argv[]) {
   Opts opts = parse_opts();
 
   logger_init(opts.verbose);
+  std::cout << "verbose: " << opts.verbose << "\n";
   std::cout << "threads  = " << opts.threads << "\n";
   std::cout << "tasks    = " << opts.tasks << "\n";
   std::cout << "switches = " << opts.switches << "\n";

--- a/runtime/include/verifying_macro.h
+++ b/runtime/include/verifying_macro.h
@@ -55,10 +55,10 @@ struct TargetMethod<int, Target, Args...> {
                std::function<std::tuple<Args...>(size_t)> gen, Method method) {
     auto builder =
         [gen = std::move(gen), method_name, method = std::move(method)](
-            void *this_ptr, size_t thread_num) -> Task {
+            void *this_ptr, size_t thread_num, int task_id) -> Task {
       auto args = std::shared_ptr<void>(new std::tuple(gen(thread_num)));
       auto coro = Coro<Target, Args...>::New(
-          method, this_ptr, args, &ltest::toStringArgs<Args...>, method_name);
+          method, this_ptr, args, &ltest::toStringArgs<Args...>, method_name, task_id);
       if (ltest::generators::generated_token) {
         coro->SetToken(ltest::generators::generated_token);
         ltest::generators::generated_token.reset();
@@ -89,11 +89,11 @@ struct TargetMethod<void, Target, Args...> {
                std::function<std::tuple<Args...>(size_t)> gen, Method method) {
     auto builder =
         [gen = std::move(gen), method_name, method = std::move(method)](
-            void *this_ptr, size_t thread_num) -> Task {
+            void *this_ptr, size_t thread_num, int task_id) -> Task {
       auto wrapper = Wrapper<Target, decltype(method), Args...>{method};
       auto args = std::shared_ptr<void>(new std::tuple(gen(thread_num)));
       auto coro = Coro<Target, Args...>::New(
-          wrapper, this_ptr, args, &ltest::toStringArgs<Args...>, method_name);
+          wrapper, this_ptr, args, &ltest::toStringArgs<Args...>, method_name, task_id);
       if (ltest::generators::generated_token) {
         coro->SetToken(ltest::generators::generated_token);
         ltest::generators::generated_token.reset();

--- a/runtime/lib.cpp
+++ b/runtime/lib.cpp
@@ -14,6 +14,8 @@ Task CoroBase::GetPtr() { return shared_from_this(); }
 
 void CoroBase::SetToken(std::shared_ptr<Token> token) { this->token = token; }
 
+void CoroBase::SetRemoved(bool is_removed) { this->is_removed = is_removed; }
+
 void CoroBase::Resume() {
   this_coro = this->GetPtr();
   assert(!this_coro->IsReturned() && this_coro->ctx);

--- a/runtime/lib.cpp
+++ b/runtime/lib.cpp
@@ -25,6 +25,14 @@ void CoroBase::Resume() {
   this_coro.reset();
 }
 
+int CoroBase::GetId() const {
+  return id;
+}
+
+bool CoroBase::IsRemoved() const {
+  return is_removed;
+}
+
 int CoroBase::GetRetVal() const {
   assert(IsReturned());
   return ret;

--- a/runtime/minimization.cpp
+++ b/runtime/minimization.cpp
@@ -1,0 +1,118 @@
+#include "minimization.h"
+
+
+// greedy
+void GreedyRoundMinimizor::Minimize(
+StrategyScheduler& sched,
+Scheduler::Histories& nonlinear_history
+) const {
+  std::vector<std::reference_wrapper<const Task>> tasks;
+
+  for (const HistoryEvent& event : nonlinear_history.second) {
+    if (std::holds_alternative<Invoke>(event)) {
+      tasks.push_back(std::get<Invoke>(event).GetTask());
+    }
+  }
+
+  // remove single task
+  for (auto& task : tasks) {
+    if (task.get()->IsRemoved()) continue;
+
+    // log() << "Try to remove task with id: " << task.get()->GetId() << "\n";
+    auto new_histories = OnSingleTaskRemoved(sched, nonlinear_history, task.get());
+
+    if (new_histories.has_value()) {
+      nonlinear_history.first.swap(new_histories.value().first);
+      nonlinear_history.second.swap(new_histories.value().second);
+      task.get()->SetRemoved(true);
+    }
+  }
+
+  // remove two tasks (for operations with semantics of add/remove)
+  for (size_t i = 0; i < tasks.size(); ++i) {
+    auto& task_i = tasks[i];
+    if (task_i.get()->IsRemoved()) continue;
+    
+    for (size_t j = i + 1; j < tasks.size(); ++j) {
+      auto& task_j = tasks[j];
+      if (task_j.get()->IsRemoved()) continue;
+      
+      // log() << "Try to remove tasks with ids: " << task_i.get()->GetId() << " and "
+      //       << task_j.get()->GetId() << "\n";
+      auto new_histories = OnTwoTasksRemoved(sched, nonlinear_history, task_i.get(), task_j.get());
+
+      if (new_histories.has_value()) {
+        // sequential history (Invoke/Response events) must have even number of history events
+        assert(new_histories.value().second.size() % 2 == 0);
+
+        nonlinear_history.first.swap(new_histories.value().first);
+        nonlinear_history.second.swap(new_histories.value().second);
+
+        task_i.get()->SetRemoved(true);
+        task_j.get()->SetRemoved(true);
+        break; // tasks (i, j) were removed, so go to the next iteration of i
+      }
+    }
+  }
+
+  // replay minimized round one last time to put coroutines in `returned` state
+  // (because multiple failed attempts to minimize new scenarios could leave tasks in invalid state)
+  sched.ReplayRound(StrategyScheduler::GetTasksOrdering(nonlinear_history.first, {}));
+}
+
+
+// same interleaving
+Scheduler::Result SameInterleavingMinimizor::OnSingleTaskRemoved(
+  StrategyScheduler& sched,
+  const Scheduler::Histories& nonlinear_history,
+  const Task& task
+) const {
+  std::vector<int> new_ordering = StrategyScheduler::GetTasksOrdering(nonlinear_history.first, { task->GetId() });
+  return sched.ReplayRound(new_ordering);
+}
+
+Scheduler::Result SameInterleavingMinimizor::OnTwoTasksRemoved(
+  StrategyScheduler& sched,
+  const Scheduler::Histories& nonlinear_history,
+  const Task& task_i,
+  const Task& task_j
+) const {
+  std::vector<int> new_ordering = StrategyScheduler::GetTasksOrdering(nonlinear_history.first, { task_i->GetId(), task_j->GetId() });
+  return sched.ReplayRound(new_ordering);
+}
+
+// strategy exploration
+StrategyExplorationMinimizor::StrategyExplorationMinimizor(int runs_): runs(runs_) {}
+
+Scheduler::Result StrategyExplorationMinimizor::OnSingleTaskRemoved(
+  StrategyScheduler& sched,
+  const Scheduler::Histories& nonlinear_history,
+  const Task& task
+) const {
+  task->SetRemoved(true);
+  Scheduler::Result new_histories = sched.ExploreRound(runs);
+
+  if (!new_histories.has_value()) {
+    task->SetRemoved(false);
+  }
+
+  return new_histories;
+}
+
+Scheduler::Result StrategyExplorationMinimizor::OnTwoTasksRemoved(
+  StrategyScheduler& sched,
+  const Scheduler::Histories& nonlinear_history,
+  const Task& task_i,
+  const Task& task_j
+) const {
+  task_i->SetRemoved(true);
+  task_j->SetRemoved(true);
+  Scheduler::Result new_histories = sched.ExploreRound(runs);
+
+  if (!new_histories.has_value()) {
+    task_i->SetRemoved(false);
+    task_j->SetRemoved(false);
+  }
+
+  return new_histories;
+}

--- a/runtime/scheduler.cpp
+++ b/runtime/scheduler.cpp
@@ -18,7 +18,7 @@ StrategyScheduler::StrategyScheduler(Strategy &sched_class,
       max_rounds(max_rounds),
       minimization_runs(minimization_runs) {}
 
-Scheduler::Result StrategyScheduler::runRound() {
+Scheduler::Result StrategyScheduler::RunRound() {
   // History of invoke and response events which is required for the checker
   SeqHistory sequential_history;
   // Full history of the current execution in the Run function
@@ -51,7 +51,7 @@ Scheduler::Result StrategyScheduler::runRound() {
   return std::nullopt;
 }
 
-StrategyScheduler::Result StrategyScheduler::exploreRound(int runs) {
+StrategyScheduler::Result StrategyScheduler::ExploreRound(int runs) {
   for (int i = 0; i < runs; ++i) {
     // log() << "Run " << i + 1 << "/" << runs << "\n";
     strategy.ResetCurrentRound();
@@ -86,7 +86,7 @@ StrategyScheduler::Result StrategyScheduler::exploreRound(int runs) {
   return std::nullopt;
 }
 
-StrategyScheduler::Result StrategyScheduler::replayRound(const std::vector<int>& tasks_ordering) {
+StrategyScheduler::Result StrategyScheduler::ReplayRound(const std::vector<int>& tasks_ordering) {
   strategy.ResetCurrentRound();
 
   // History of invoke and response events which is required for the checker
@@ -141,7 +141,7 @@ StrategyScheduler::Result StrategyScheduler::replayRound(const std::vector<int>&
   return std::nullopt;
 }
 
-std::vector<int> StrategyScheduler::getTasksOrdering(
+std::vector<int> StrategyScheduler::GetTasksOrdering(
   const FullHistory& full_history,
   const std::unordered_set<int> exclude_task_ids
 ) {
@@ -155,17 +155,17 @@ std::vector<int> StrategyScheduler::getTasksOrdering(
   return tasks_ordering;
 }
 
-void StrategyScheduler::minimize(
+void StrategyScheduler::Minimize(
   Scheduler::Histories& nonlinear_history,
   const RoundMinimizor& minimizor
 ) {
-  minimizor.minimize(*this, nonlinear_history);
+  minimizor.Minimize(*this, nonlinear_history);
 }
 
 Scheduler::Result StrategyScheduler::Run() {
   for (size_t i = 0; i < max_rounds; ++i) {
     log() << "run round: " << i << "\n";
-    auto histories = runRound();
+    auto histories = RunRound();
 
     if (histories.has_value()) {
       auto& [full_history, sequential_history] = histories.value();
@@ -174,10 +174,10 @@ Scheduler::Result StrategyScheduler::Run() {
       pretty_printer.PrettyPrint(sequential_history, log());
       
       log() << "Minimizing same interleaving...\n";
-      minimize(histories.value(), SameInterleavingMinimizor());
+      Minimize(histories.value(), SameInterleavingMinimizor());
 
       log() << "Minimizing with rescheduling (runs: " << minimization_runs << ")...\n";
-      minimize(histories.value(), StrategyExplorationMinimizor(minimization_runs));
+      Minimize(histories.value(), StrategyExplorationMinimizor(minimization_runs));
 
       return histories;
     }

--- a/runtime/scheduler.cpp
+++ b/runtime/scheduler.cpp
@@ -46,38 +46,96 @@ Scheduler::Result StrategyScheduler::runRound() {
   return std::nullopt;
 }
 
-// TODO: refactor
-// StrategyScheduler::Result StrategyScheduler::replayRound(FullHistory tasks_order) {
-//   // History of invoke and response events which is required for the checker
-//   SeqHistory sequential_history;
+StrategyScheduler::Result StrategyScheduler::replayRound(const std::vector<int>& tasks_ordering) {
+  strategy.ResetCurrentRound();
 
-//   for (std::reference_wrapper<Task> next_task : tasks_order) {
-    
-//   }
-// }
+  // History of invoke and response events which is required for the checker
+  FullHistory full_history;
+  SeqHistory sequential_history;
+  // TODO: `IsRunning` field might be added to `Task` instead
+  std::unordered_set<int> started_tasks;
+
+  for (int next_task_id : tasks_ordering) {
+    bool is_new = started_tasks.contains(next_task_id) ? false : started_tasks.insert(next_task_id).second;
+    auto task_info = strategy.GetTask(next_task_id);
+
+    if (!task_info.has_value()) {
+      std::cerr << "No task with id " << next_task_id << " exists in round" << std::endl;
+      throw std::runtime_error("Invalid task id");
+    }
+
+    auto [next_task, thread_id] = task_info.value();
+    if (is_new) {
+      sequential_history.emplace_back(Invoke(next_task, thread_id));
+    }
+    full_history.emplace_back(next_task);
+
+    log() << "Resume task: id=" << next_task_id << ", " << next_task->GetName() << ", thread-id=" << thread_id << "\n";
+
+    next_task->Resume();
+    if (next_task->IsReturned()) {
+      auto result = next_task->GetRetVal();
+      sequential_history.emplace_back(Response(next_task, result, thread_id));
+    }
+  }
+
+  log() << "Replayed round: tasks ordering = ";
+  for (size_t i = 0; i < tasks_ordering.size(); ++i) {
+    int task_id = tasks_ordering[i];
+    log() << task_id;
+    if (i != tasks_ordering.size() - 1) log() << ",";
+    log() << " "; 
+  }
+  log() << "\n";
+
+  pretty_printer.PrettyPrint(sequential_history, log());
+
+  if (!checker.Check(sequential_history)) {
+    return std::make_pair(full_history, sequential_history);
+  }
+
+  return std::nullopt;
+}
+
+std::vector <int> StrategyScheduler::getTasksOrdering(const FullHistory& full_history) const {
+  std::vector <int> tasks_ordering;
+  tasks_ordering.reserve(full_history.size());
+  
+  for (auto& task : full_history) {
+    tasks_ordering.emplace_back(task.get()->GetId());
+  }
+
+  return tasks_ordering;
+}
 
 Scheduler::Result StrategyScheduler::Run() {
   for (size_t i = 0; i < max_rounds; ++i) {
     log() << "run round: " << i << "\n";
-    auto seq_history = runRound();
-    if (seq_history.has_value()) {
+    auto histories = runRound();
 
+    if (histories.has_value()) {
       log() << "found failing sequential history:\n";
-      auto& seq = seq_history.value().second;
-      for (auto history_point : seq) {
+      auto& [full_history, sequential_history] = histories.value();
+
+      // Print the sequential history for debugging
+      for (auto history_point : sequential_history) {
         if (std::holds_alternative<Invoke>(history_point)) {
           Invoke& inv = std::get<Invoke>(history_point);
           log() << "i(" << inv.thread_id << ", '" << inv.GetTask()->GetName()  << "'), ";
         }
         else {
-          Response& resp = std::get<Response>(history_point);
-          log() << "r(" << resp.thread_id << ", '" << resp.GetTask()->GetName() << "'): " << resp.result << ", ";
+          Response& response = std::get<Response>(history_point);
+          log() << "r(" << response.thread_id << ", '" << response.GetTask()->GetName() << "'): " << response.result << ", ";
         }
       }
       log() << "\n";
 
       // TODO: add minimization here
-      return seq_history;
+      log() << "Replaying round for test\n";
+      std::vector <int> tasks_ordering = getTasksOrdering(full_history);
+      auto res = replayRound(tasks_ordering);
+
+      return histories;
     }
     log() << "===============================================\n\n";
     log().flush();

--- a/runtime/scheduler.cpp
+++ b/runtime/scheduler.cpp
@@ -173,10 +173,10 @@ Scheduler::Result StrategyScheduler::Run() {
       pretty_printer.PrettyPrint(sequential_history, log());
       
       log() << "Minimizing same interleaving...\n";
-      minimize(histories.value(), InterleavingMinimizor());
+      minimize(histories.value(), SameInterleavingMinimizor());
 
       log() << "Minimizing with rescheduling (runs: " << exploration_runs << ")...\n";
-      minimize(histories.value(), StrategyMinimizor(exploration_runs));
+      minimize(histories.value(), StrategyExplorationMinimizor(exploration_runs));
 
       return histories;
     }

--- a/runtime/scheduler.cpp
+++ b/runtime/scheduler.cpp
@@ -82,16 +82,7 @@ StrategyScheduler::Result StrategyScheduler::replayRound(const std::vector<int>&
     }
   }
 
-  // log() << "Replayed round: tasks ordering = ";
-  // for (size_t i = 0; i < tasks_ordering.size(); ++i) {
-  //   int task_id = tasks_ordering[i];
-  //   log() << task_id;
-  //   if (i != tasks_ordering.size() - 1) log() << ",";
-  //   log() << " "; 
-  // }
-  // log() << "\n";
-
-  pretty_printer.PrettyPrint(sequential_history, log());
+  //pretty_printer.PrettyPrint(sequential_history, log());
 
   if (!checker.Check(sequential_history)) {
     return std::make_pair(full_history, sequential_history);
@@ -127,7 +118,7 @@ void StrategyScheduler::minimize(
   for (auto& task : tasks) {
     int task_id = task.get()->GetId();
 
-    log() << "Try to remove task with id: " << task_id << "\n";
+    // log() << "Try to remove task with id: " << task_id << "\n";
     std::vector<int> new_ordering = getTasksOrdering(nonlinear_history.first, { task_id });
     auto new_histories = replayRound(new_ordering);
 
@@ -151,7 +142,7 @@ void StrategyScheduler::minimize(
       
       if (task_i_id == task_j_id) continue;
       
-      log() << "Try to remove task with id: " << task_i_id << " and " << task_j_id << "\n";
+      // log() << "Try to remove task with id: " << task_i_id << " and " << task_j_id << "\n";
       std::vector<int> new_ordering = getTasksOrdering(nonlinear_history.first, { task_i_id, task_j_id });
       auto new_histories = replayRound(new_ordering);
 
@@ -168,10 +159,8 @@ void StrategyScheduler::minimize(
     }
   }
 
-  // replay round one last time to get returned coroutine states
+  // replay round one last time to put coroutines in `returned` state
   replayRound(getTasksOrdering(nonlinear_history.first, {}));
-
-  log() << "Finished minimization\n";
 }
 
 Scheduler::Result StrategyScheduler::Run() {
@@ -180,23 +169,8 @@ Scheduler::Result StrategyScheduler::Run() {
     auto histories = runRound();
 
     if (histories.has_value()) {
-      log() << "found failing sequential history:\n";
       auto& [full_history, sequential_history] = histories.value();
 
-      // Print the sequential history for debugging
-      for (auto history_point : sequential_history) {
-        if (std::holds_alternative<Invoke>(history_point)) {
-          Invoke& inv = std::get<Invoke>(history_point);
-          log() << "i(" << inv.thread_id << ", '" << inv.GetTask()->GetName()  << "'), ";
-        }
-        else {
-          Response& response = std::get<Response>(history_point);
-          log() << "r(" << response.thread_id << ", '" << response.GetTask()->GetName() << "'): " << response.result << ", ";
-        }
-      }
-      log() << "\n";
-
-      // TODO: add minimization here
       log() << "Full nonlinear scenario: \n";
       pretty_printer.PrettyPrint(sequential_history, log());
       
@@ -204,11 +178,6 @@ Scheduler::Result StrategyScheduler::Run() {
       minimize(histories.value());
 
       return histories;
-
-      // log() << "Replaying round for test\n";
-      // std::vector <int> tasks_ordering = getTasksOrdering(full_history);
-      // auto res = replayRound(tasks_ordering);
-      // return histories;
     }
     log() << "===============================================\n\n";
     log().flush();
@@ -217,27 +186,3 @@ Scheduler::Result StrategyScheduler::Run() {
 
   return std::nullopt;
 }
-
-// Scheduler::Result StrategyScheduler::minimizeHistory(Result nonlinear_history) {
-//   if (!nonlinear_history.has_value()) return nonlinear_history;
-
-//   auto& full_history = nonlinear_history.value().first;
-//   auto& sequential_history = nonlinear_history.value().second;
-
-//   log() << "Minimizing history:\n";
-//   pretty_printer.PrettyPrint(sequential_history, log());
-  
-//   int task_idx_rm = 0; // task index in the sequential_history which we try to remove
-
-//   while (task_idx_rm < sequential_history.size()) {
-//     while (std::holds_alternative<Response>(sequential_history[task_idx_rm])) {
-//       task_idx_rm++;
-//     }
-
-//     const Task& removed_task = std::get<Invoke>(sequential_history[task_idx_rm]).GetTask();
-//     log() << "Try remove task: (" << task_idx_rm << ") " << removed_task->GetName() << "\n";
-    
-//     // create a new `std::vector<int> threads_order`, in which `removed_task` will be excluded
-    
-//   }
-// }

--- a/runtime/scheduler.cpp
+++ b/runtime/scheduler.cpp
@@ -46,11 +46,37 @@ Scheduler::Result StrategyScheduler::runRound() {
   return std::nullopt;
 }
 
+// TODO: refactor
+// StrategyScheduler::Result StrategyScheduler::replayRound(FullHistory tasks_order) {
+//   // History of invoke and response events which is required for the checker
+//   SeqHistory sequential_history;
+
+//   for (std::reference_wrapper<Task> next_task : tasks_order) {
+    
+//   }
+// }
+
 Scheduler::Result StrategyScheduler::Run() {
   for (size_t i = 0; i < max_rounds; ++i) {
     log() << "run round: " << i << "\n";
     auto seq_history = runRound();
     if (seq_history.has_value()) {
+
+      log() << "found failing sequential history:\n";
+      auto& seq = seq_history.value().second;
+      for (auto history_point : seq) {
+        if (std::holds_alternative<Invoke>(history_point)) {
+          Invoke& inv = std::get<Invoke>(history_point);
+          log() << "i(" << inv.thread_id << ", '" << inv.GetTask()->GetName()  << "'), ";
+        }
+        else {
+          Response& resp = std::get<Response>(history_point);
+          log() << "r(" << resp.thread_id << ", '" << resp.GetTask()->GetName() << "'): " << resp.result << ", ";
+        }
+      }
+      log() << "\n";
+
+      // TODO: add minimization here
       return seq_history;
     }
     log() << "===============================================\n\n";
@@ -60,3 +86,27 @@ Scheduler::Result StrategyScheduler::Run() {
 
   return std::nullopt;
 }
+
+// Scheduler::Result StrategyScheduler::minimizeHistory(Result nonlinear_history) {
+//   if (!nonlinear_history.has_value()) return nonlinear_history;
+
+//   auto& full_history = nonlinear_history.value().first;
+//   auto& sequential_history = nonlinear_history.value().second;
+
+//   log() << "Minimizing history:\n";
+//   pretty_printer.PrettyPrint(sequential_history, log());
+  
+//   int task_idx_rm = 0; // task index in the sequential_history which we try to remove
+
+//   while (task_idx_rm < sequential_history.size()) {
+//     while (std::holds_alternative<Response>(sequential_history[task_idx_rm])) {
+//       task_idx_rm++;
+//     }
+
+//     const Task& removed_task = std::get<Invoke>(sequential_history[task_idx_rm]).GetTask();
+//     log() << "Try remove task: (" << task_idx_rm << ") " << removed_task->GetName() << "\n";
+    
+//     // create a new `std::vector<int> threads_order`, in which `removed_task` will be excluded
+    
+//   }
+// }

--- a/runtime/scheduler.cpp
+++ b/runtime/scheduler.cpp
@@ -123,7 +123,6 @@ std::vector<int> StrategyScheduler::getTasksOrdering(const FullHistory& full_his
 void StrategyScheduler::minimize(
   std::pair<Scheduler::FullHistory, Scheduler::SeqHistory>& nonlinear_history
 ) {
-  std::unordered_set<int> removed_tasks;
   std::vector<std::reference_wrapper<const Task>> tasks;
 
   for (const HistoryEvent& event : nonlinear_history.second) {
@@ -143,7 +142,6 @@ void StrategyScheduler::minimize(
     if (new_histories.has_value()) {
       nonlinear_history.first.swap(new_histories.value().first);
       nonlinear_history.second.swap(new_histories.value().second);
-      removed_tasks.insert(task_id);
       task.get()->SetRemoved(true);
     }
   }
@@ -170,9 +168,6 @@ void StrategyScheduler::minimize(
 
         nonlinear_history.first.swap(new_histories.value().first);
         nonlinear_history.second.swap(new_histories.value().second);
-        
-        removed_tasks.insert(task_i_id);
-        removed_tasks.insert(task_j_id);
         
         task_i.get()->SetRemoved(true);
         task_j.get()->SetRemoved(true);

--- a/runtime/scheduler.cpp
+++ b/runtime/scheduler.cpp
@@ -211,6 +211,7 @@ void StrategyScheduler::minimize(
 }
 
 void StrategyScheduler::minimizeSameInterleaving(Scheduler::Histories& nonlinear_history) {
+  // TODO: get rid of this lambdas
   SingleTaskRemovedCallback onSingleTaskRemoved = [](
     StrategyScheduler *this_,
     const Scheduler::Histories& nonlinear_history,
@@ -234,6 +235,7 @@ void StrategyScheduler::minimizeSameInterleaving(Scheduler::Histories& nonlinear
 }
 
 void StrategyScheduler::minimizeWithStrategy(Scheduler::Histories& nonlinear_history) {
+  // TODO: get rid of this lambdas
   SingleTaskRemovedCallback onSingleTaskRemoved = [](
     StrategyScheduler* this_,
     const Scheduler::Histories& nonlinear_history,

--- a/runtime/scheduler.cpp
+++ b/runtime/scheduler.cpp
@@ -8,12 +8,15 @@
 StrategyScheduler::StrategyScheduler(Strategy &sched_class,
                                      ModelChecker &checker,
                                      PrettyPrinter &pretty_printer,
-                                     size_t max_tasks, size_t max_rounds)
+                                     size_t max_tasks,
+                                     size_t max_rounds,
+                                     size_t minimization_runs)
     : strategy(sched_class),
       checker(checker),
       pretty_printer(pretty_printer),
       max_tasks(max_tasks),
-      max_rounds(max_rounds) {}
+      max_rounds(max_rounds),
+      minimization_runs(minimization_runs) {}
 
 Scheduler::Result StrategyScheduler::runRound() {
   // History of invoke and response events which is required for the checker
@@ -163,8 +166,6 @@ Scheduler::Result StrategyScheduler::Run() {
   for (size_t i = 0; i < max_rounds; ++i) {
     log() << "run round: " << i << "\n";
     auto histories = runRound();
-    // TODO: make `exploration_runs` a command-line argument
-    int exploration_runs = 10;
 
     if (histories.has_value()) {
       auto& [full_history, sequential_history] = histories.value();
@@ -175,8 +176,8 @@ Scheduler::Result StrategyScheduler::Run() {
       log() << "Minimizing same interleaving...\n";
       minimize(histories.value(), SameInterleavingMinimizor());
 
-      log() << "Minimizing with rescheduling (runs: " << exploration_runs << ")...\n";
-      minimize(histories.value(), StrategyExplorationMinimizor(exploration_runs));
+      log() << "Minimizing with rescheduling (runs: " << minimization_runs << ")...\n";
+      minimize(histories.value(), StrategyExplorationMinimizor(minimization_runs));
 
       return histories;
     }

--- a/runtime/verifying.cpp
+++ b/runtime/verifying.cpp
@@ -66,7 +66,8 @@ StrategyType FromLiteral(std::string &&a) {
 DEFINE_int32(threads, 2, "Number of threads");
 DEFINE_int32(tasks, 15, "Number of tasks");
 DEFINE_int32(switches, 100000000, "Number of switches");
-DEFINE_int32(rounds, 5, "Number of switches");
+DEFINE_int32(rounds, 5, "Number of rounds");
+DEFINE_int32(minimization_runs, 10, "Number of runs during round minimization");
 DEFINE_bool(verbose, false, "Verbosity");
 DEFINE_string(strategy, GetLiteral(StrategyType::RR), "Strategy");
 DEFINE_string(weights, "", "comma-separated list of weights for threads");
@@ -78,6 +79,7 @@ Opts parse_opts() {
   opts.tasks = FLAGS_tasks;
   opts.switches = FLAGS_switches;
   opts.rounds = FLAGS_rounds;
+  opts.minimization_runs = FLAGS_minimization_runs;
   opts.verbose = FLAGS_verbose;
   opts.typ = FromLiteral(std::move(FLAGS_strategy));
   std::vector<int> thread_weights;

--- a/runtime/verifying.cpp
+++ b/runtime/verifying.cpp
@@ -78,6 +78,7 @@ Opts parse_opts() {
   opts.tasks = FLAGS_tasks;
   opts.switches = FLAGS_switches;
   opts.rounds = FLAGS_rounds;
+  opts.verbose = FLAGS_verbose;
   opts.typ = FromLiteral(std::move(FLAGS_strategy));
   std::vector<int> thread_weights;
   if (FLAGS_weights != "") {


### PR DESCRIPTION
Done:
- Added round replaying with preserved interleaving scheduling
- Added round exploration with the same tasks but different interleavings (which are generated according to the strategy)
- Greedy round minimization with:
   - Preserving the same interleaving
   - Exploring different interleavings with a budget according to strategy

Issues:
> Can be done in separate PR later
- No minimization for `tla` strategy (it is an instance of `Scheduler` class rather than the `Strategy`, which complicates implementation for it). Maybe reasonable to split `TLAScheduler` class in two parts, one with strategy implementation and the second one with running the switches.