### PR TITLE
Remove assertion for all tasks completion during minimization

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -2,7 +2,7 @@ name: run-tests
 on:
   workflow_call:
 jobs:
-  #TODO: made a seperate build job to build only one time
+  #TODO: make a seperate build job to build only one time
   unit-tests:
     runs-on: ubuntu-latest
     defaults:

--- a/runtime/include/pct_strategy.h
+++ b/runtime/include/pct_strategy.h
@@ -185,7 +185,7 @@ struct PctStrategy : public BaseStrategyWithThreads<TargetObj, Verifier> {
     // current_depth have been increased
     size_t new_k = std::reduce(k_statistics.begin(), k_statistics.end()) /
                    k_statistics.size();
-    log() << "k: " << new_k << "\n";
+    // log() << "k: " << new_k << "\n";
     PrepareForDepth(current_depth, new_k);
   }
 

--- a/runtime/minimization.cpp
+++ b/runtime/minimization.cpp
@@ -62,10 +62,8 @@ void GreedyRoundMinimizor::Minimize(
           OnTasksRemoved(sched, nonlinear_history, {task_i_id, task_j_id});
 
       if (new_histories.has_value()) {
-        // sequential history (Invoke/Response events) must have even number of
-        // history events
-        assert(new_histories.value().second.size() % 2 == 0);
-
+        // sequential history (Invoke/Response events) could have odd number of
+        // history events in case if some task are not completed which is allowed by linearizability checker
         nonlinear_history.first.swap(new_histories.value().first);
         nonlinear_history.second.swap(new_histories.value().second);
 

--- a/verifying/targets/CMakeLists.txt
+++ b/verifying/targets/CMakeLists.txt
@@ -41,38 +41,37 @@ add_custom_target(verify-targets
     ${VERIFY_TARGET_LIST}
 )
 
-#Fails randomly when running in RelWithAssert
-# add_integration_test("nonlinear_queue_random_minimization" "verify" TRUE 
-#     nonlinear_queue --tasks 40 --rounds 1000000 --strategy random --minimize
-# )
+add_integration_test("nonlinear_queue_random_minimization" "verify" TRUE 
+    nonlinear_queue --tasks 40 --rounds 1000000 --strategy random --minimize
+)
 
-# add_integration_test("nonlinear_queue_pct_minimization" "verify" TRUE 
-#     nonlinear_queue --tasks 40 --rounds 1000000 --strategy pct --minimize
-# )
+add_integration_test("nonlinear_queue_pct_minimization" "verify" TRUE 
+    nonlinear_queue --tasks 40 --rounds 1000000 --strategy pct --minimize
+)
 
-# add_integration_test("nonlinear_ms_queue_random_minimization" "verify" TRUE 
-#     nonlinear_ms_queue --tasks 40 --rounds 1000000 --strategy random --minimize
-# )
+add_integration_test("nonlinear_ms_queue_random_minimization" "verify" TRUE 
+    nonlinear_ms_queue --tasks 40 --rounds 1000000 --strategy random --minimize
+)
 
-# add_integration_test("nonlinear_ms_queue_pct_minimization" "verify" TRUE 
-#     nonlinear_ms_queue --tasks 40 --rounds 1000000 --strategy pct --minimize
-# )
+add_integration_test("nonlinear_ms_queue_pct_minimization" "verify" TRUE 
+    nonlinear_ms_queue --tasks 40 --rounds 1000000 --strategy pct --minimize
+)
 
-# add_integration_test("nonlinear_treiber_stack_random_minimization" "verify" TRUE 
-#     nonlinear_treiber_stack --tasks 40 --rounds 1000000 --strategy random --minimize
-# )
+add_integration_test("nonlinear_treiber_stack_random_minimization" "verify" TRUE 
+    nonlinear_treiber_stack --tasks 40 --rounds 1000000 --strategy random --minimize
+)
 
-# add_integration_test("nonlinear_treiber_stack_pct_minimization" "verify" TRUE 
-#     nonlinear_treiber_stack --tasks 40 --rounds 1000000 --strategy pct --minimize
-# )
+add_integration_test("nonlinear_treiber_stack_pct_minimization" "verify" TRUE 
+    nonlinear_treiber_stack --tasks 40 --rounds 1000000 --strategy pct --minimize
+)
 
-# add_integration_test("nonlinear_set_random_minimization" "verify" TRUE 
-#     nonlinear_set --tasks 40 --rounds 1000000 --strategy random --minimize
-# )
+add_integration_test("nonlinear_set_random_minimization" "verify" TRUE 
+    nonlinear_set --tasks 40 --rounds 1000000 --strategy random --minimize
+)
 
-# add_integration_test("nonlinear_set_pct_minimization" "verify" TRUE 
-#     nonlinear_set --tasks 40 --rounds 1000000 --strategy pct --minimize
-# )
+add_integration_test("nonlinear_set_pct_minimization" "verify" TRUE 
+    nonlinear_set --tasks 40 --rounds 1000000 --strategy pct --minimize
+)
 
 add_integration_test("unique_args" "verify" FALSE 
     unique_args


### PR DESCRIPTION
- Удалил assertion, который падал ранее при включенной минимизации. Это разумно, поскольку мы позволяем последним таскам в потоках остаться незавершенным, т.к. linearizability checker такое разрешает 