### PR TITLE
Dual structure 1: Extract recursive linearization search

### DIFF
--- a/runtime/include/lincheck_recursive.h
+++ b/runtime/include/lincheck_recursive.h
@@ -1,12 +1,71 @@
 #pragma once
 
 #include <functional>
-#include <numeric>
+#include <stdexcept>
+#include <string_view>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>
 
 #include "lincheck.h"
+#include "linearization_search.h"
 
-// This is the simplest wg version, it doesn't contain any optimizations, it's
-// slow but useful for stress tests of other implementations
+namespace ltest::detail {
+
+struct RecursiveHistoryEventInfo {
+  bool is_invoke{};
+  bool is_response{};
+  std::string_view name{};
+  void* args{};
+  size_t response_index{kNoResponseIndex};
+  const ValueWrapper* result{};
+};
+
+inline std::vector<RecursiveHistoryEventInfo> BuildRecursiveHistoryEventInfo(
+    const std::vector<HistoryEvent>& history) {
+  std::vector<RecursiveHistoryEventInfo> info(history.size());
+  std::unordered_map<const CoroBase*, size_t> invoke_by_task;
+  std::unordered_map<int, size_t> invoke_by_op_id;
+  invoke_by_task.reserve(history.size());
+  invoke_by_op_id.reserve(history.size());
+
+  for (size_t i = 0; i < history.size(); ++i) {
+    auto& dst = info[i];
+    if (history[i].index() == 0) {
+      const auto& invoke = std::get<Invoke>(history[i]);
+      const auto& task = invoke.GetTask();
+      dst.is_invoke = true;
+      dst.name = task->GetName();
+      dst.args = task->GetArgs();
+      invoke_by_task[task.get()] = i;
+      invoke_by_op_id[task->GetId()] = i;
+      continue;
+    }
+
+    const auto& response = std::get<Response>(history[i]);
+    const auto& task = response.GetTask();
+    dst.is_response = true;
+    dst.name = task->GetName();
+    dst.args = task->GetArgs();
+    dst.result = &response.result;
+
+    auto invoke_it = invoke_by_task.find(task.get());
+    if (invoke_it != invoke_by_task.end()) {
+      info[invoke_it->second].response_index = i;
+    } else {
+      auto by_id = invoke_by_op_id.find(task->GetId());
+      if (by_id != invoke_by_op_id.end()) {
+        info[by_id->second].response_index = i;
+      }
+    }
+  }
+
+  return info;
+}
+
+}  // namespace ltest::detail
+
+// Recursive checker adapter over the shared backtracking search.
 template <class LinearSpecificationObject,
           class SpecificationObjectHash = std::hash<LinearSpecificationObject>,
           class SpecificationObjectEqual =
@@ -36,10 +95,10 @@ LinearizabilityCheckerRecursive<LinearSpecificationObject,
         LinearizabilityCheckerRecursive::MethodMap specification_methods,
         LinearSpecificationObject first_state)
     : specification_methods(specification_methods), first_state(first_state) {
-  if (!std::is_copy_assignable_v<LinearSpecificationObject>) {
+  if (!std::is_copy_constructible_v<LinearSpecificationObject>) {
     // TODO: should do it in the compile time
     throw std::invalid_argument(
-        "LinearSpecificationObject type have to be is_copy_assignable_v");
+        "LinearSpecificationObject type have to be copy constructible");
   }
 }
 
@@ -48,81 +107,48 @@ template <class LinearSpecificationObject, class SpecificationObjectHash,
 bool LinearizabilityCheckerRecursive<
     LinearSpecificationObject, SpecificationObjectHash,
     SpecificationObjectEqual>::Check(const std::vector<HistoryEvent>& history) {
-  // It's a crunch, but it's required because the semantics of this
-  // implementation must be the same as the semantics of the non-recursive
-  // implementation
-  if (history.empty()) {
-    return true;
+  const auto event_info = ltest::detail::BuildRecursiveHistoryEventInfo(history);
+  std::vector<const Method*> method_by_event(history.size(), nullptr);
+
+  for (size_t i = 0; i < event_info.size(); ++i) {
+    if (!event_info[i].is_invoke) continue;
+
+    auto method_it = specification_methods.find(std::string(event_info[i].name));
+    if (method_it == specification_methods.end()) {
+      throw std::runtime_error("No method in spec for: " +
+                               std::string(event_info[i].name));
+    }
+    method_by_event[i] = &method_it->second;
   }
-  std::map<size_t, size_t> inv_res = get_inv_res_mapping(history);
 
-  std::function<bool(const std::vector<HistoryEvent>&, std::vector<bool>&,
-                     LinearSpecificationObject)>
-      recursive_step;
+  struct Adapter {
+    const std::vector<ltest::detail::RecursiveHistoryEventInfo>& events;
+    const std::vector<const Method*>& methods;
 
-  recursive_step = [&](const std::vector<HistoryEvent>& history,
-                       std::vector<bool>& linearized,
-                       LinearSpecificationObject data_structure_state) -> bool {
-    // the fixed_history is empty
-    if (std::reduce(linearized.begin(), linearized.end(), true,
-                    std::bit_and<>())) {
-      return true;
+    [[nodiscard]] bool IsInvoke(size_t index) const {
+      return events[index].is_invoke;
     }
 
-    // walk all minimal operations
-    for (size_t i = 0; i < history.size(); ++i) {
-      // we could think that fixed_history doesn't contain events that already
-      // have been linearized
-      if (linearized[i]) {
-        continue;
-      }
-
-      // all next operations are not minimal
-      if (history[i].index() == 1) {
-        break;
-      }
-
-      Invoke minimal_op = std::get<Invoke>(history[i]);
-      assert(specification_methods.find(
-                 std::string{minimal_op.GetTask()->GetName()}) !=
-             specification_methods.end());
-      auto method = specification_methods
-                        .find(std::string{minimal_op.GetTask()->GetName()})
-                        ->second;
-
-      LinearSpecificationObject data_structure_state_copy =
-          data_structure_state;
-      // state is already have been copied, because it's the argument of the
-      // lambda
-      ValueWrapper res =
-          method(&data_structure_state_copy, minimal_op.GetTask()->GetArgs());
-      // If invoke doesn't have a response we can't check the response
-      if (inv_res.find(i) == inv_res.end()) {
-        linearized[i] = true;
-        if (recursive_step(history, linearized, data_structure_state_copy)) {
-          return true;
-        }
-        linearized[i] = false;
-        continue;
-      }
-
-      if (res == minimal_op.GetTask()->GetRetVal()) {
-        linearized[i] = true;
-        assert(inv_res.find(i) != inv_res.end());
-        linearized[inv_res[i]] = true;
-
-        if (recursive_step(history, linearized, data_structure_state_copy)) {
-          return true;
-        } else {
-          linearized[i] = false;
-          linearized[inv_res[i]] = false;
-        }
-      }
+    [[nodiscard]] bool IsResponse(size_t index) const {
+      return events[index].is_response;
     }
 
-    return false;
+    [[nodiscard]] size_t ResponseIndex(size_t index) const {
+      return events[index].response_index;
+    }
+
+    bool TryApply(size_t index, LinearSpecificationObject& state) const {
+      const auto& event = events[index];
+      ValueWrapper expected = (*methods[index])(&state, event.args);
+      if (event.response_index == ltest::detail::kNoResponseIndex) {
+        return true;
+      }
+
+      return expected == *events[event.response_index].result;
+    }
   };
 
-  std::vector<bool> linearized(history.size(), false);
-  return recursive_step(history, linearized, first_state);
+  return ltest::detail::RunRecursiveLinearizationSearchWithCache<
+      SpecificationObjectHash, SpecificationObjectEqual>(
+      history.size(), first_state, Adapter{event_info, method_by_event});
 }

--- a/runtime/include/linearization_search.h
+++ b/runtime/include/linearization_search.h
@@ -1,0 +1,195 @@
+#pragma once
+
+#include <cstddef>
+#include <concepts>
+#include <functional>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace ltest::detail {
+
+inline constexpr size_t kNoResponseIndex = static_cast<size_t>(-1);
+
+// Shared recursive linearizability search.
+//
+// Adapter contract:
+//   bool IsInvoke(size_t event_index) const;
+//   bool IsResponse(size_t event_index) const;
+//   size_t ResponseIndex(size_t invoke_index) const;
+//   bool TryApply(size_t invoke_index, State& state) const;
+template <class State>
+struct AcceptAnyCompletedLinearization {
+  bool operator()(const State&) const { return true; }
+};
+
+template <class State, class Hash, class Equal>
+concept SearchCacheableState = requires(const State& lhs, const State& rhs) {
+  { Hash{}(lhs) } -> std::convertible_to<size_t>;
+  { Equal{}(lhs, rhs) } -> std::convertible_to<bool>;
+};
+
+template <class State>
+struct SearchCacheKey {
+  std::vector<unsigned char> linearized;
+  State state;
+};
+
+template <class State, class Hash>
+struct SearchCacheKeyHash {
+  size_t operator()(const SearchCacheKey<State>& key) const {
+    size_t h = 1469598103934665603ull;
+    for (unsigned char v : key.linearized) {
+      h ^= static_cast<size_t>(v);
+      h *= 1099511628211ull;
+    }
+    h ^= Hash{}(key.state) + 0x9e3779b97f4a7c15ull +
+         (h << 6) + (h >> 2);
+    return h;
+  }
+};
+
+template <class State, class Equal>
+struct SearchCacheKeyEqual {
+  bool operator()(const SearchCacheKey<State>& lhs,
+                  const SearchCacheKey<State>& rhs) const {
+    return lhs.linearized == rhs.linearized &&
+           Equal{}(lhs.state, rhs.state);
+  }
+};
+
+template <class State, class Hash, class Equal, bool Enabled>
+struct SearchFailureCache;
+
+template <class State, class Hash, class Equal>
+struct SearchFailureCache<State, Hash, Equal, false> {
+  bool Contains(const std::vector<unsigned char>&, const State&) const {
+    return false;
+  }
+
+  void Insert(const std::vector<unsigned char>&, const State&) {}
+};
+
+template <class State, class Hash, class Equal>
+struct SearchFailureCache<State, Hash, Equal, true> {
+  bool Contains(const std::vector<unsigned char>& linearized,
+                const State& state) const {
+    return failed.contains(SearchCacheKey<State>{linearized, state});
+  }
+
+  void Insert(const std::vector<unsigned char>& linearized,
+              const State& state) {
+    failed.insert(SearchCacheKey<State>{linearized, state});
+  }
+
+  std::unordered_set<SearchCacheKey<State>,
+                     SearchCacheKeyHash<State, Hash>,
+                     SearchCacheKeyEqual<State, Equal>>
+      failed;
+};
+
+template <class Adapter>
+bool CanDropPendingInvoke(const Adapter& adapter, size_t index) {
+  if constexpr (requires { adapter.CanDropPendingInvoke(index); }) {
+    return adapter.CanDropPendingInvoke(index);
+  }
+  return false;
+}
+
+template <class State, class Adapter, class OnComplete,
+          class Hash = std::hash<State>,
+          class Equal = std::equal_to<State>>
+bool RunRecursiveLinearizationSearchImpl(size_t history_size,
+                                         const State& initial_state,
+                                         const Adapter& adapter,
+                                         const OnComplete& on_complete) {
+  if (history_size == 0) return true;
+
+  std::vector<unsigned char> linearized(history_size, false);
+  SearchFailureCache<State, Hash, Equal,
+                     SearchCacheableState<State, Hash, Equal>>
+      failed_cache;
+
+  std::function<bool(const State&, size_t)> step;
+  step = [&](const State& state, size_t linearized_count) -> bool {
+    if (linearized_count == history_size) return on_complete(state);
+    if (failed_cache.Contains(linearized, state)) return false;
+
+    for (size_t i = 0; i < history_size; ++i) {
+      if (linearized[i]) continue;
+
+      // A not-yet-linearized response closes the minimal concurrent section.
+      if (adapter.IsResponse(i)) break;
+      if (!adapter.IsInvoke(i)) continue;
+
+      const size_t response_index = adapter.ResponseIndex(i);
+      const bool has_response = response_index != kNoResponseIndex;
+      if (has_response && linearized[response_index]) continue;
+
+      if (!has_response && CanDropPendingInvoke(adapter, i)) {
+        linearized[i] = true;
+        if (step(state, linearized_count + 1)) return true;
+        linearized[i] = false;
+      }
+
+      State next_state = state;
+      if (!adapter.TryApply(i, next_state)) continue;
+
+      linearized[i] = true;
+      size_t next_linearized_count = linearized_count + 1;
+      if (has_response) {
+        linearized[response_index] = true;
+        ++next_linearized_count;
+      }
+
+      if (step(next_state, next_linearized_count)) return true;
+
+      linearized[i] = false;
+      if (has_response) linearized[response_index] = false;
+    }
+
+    failed_cache.Insert(linearized, state);
+    return false;
+  };
+
+  return step(initial_state, 0);
+}
+
+template <class Hash, class Equal, class State, class Adapter, class OnComplete>
+bool RunRecursiveLinearizationSearchWithCache(size_t history_size,
+                                              const State& initial_state,
+                                              const Adapter& adapter,
+                                              const OnComplete& on_complete) {
+  return RunRecursiveLinearizationSearchImpl<State, Adapter, OnComplete, Hash,
+                                             Equal>(
+      history_size, initial_state, adapter, on_complete);
+}
+
+template <class State, class Adapter, class OnComplete>
+bool RunRecursiveLinearizationSearch(size_t history_size,
+                                     const State& initial_state,
+                                     const Adapter& adapter,
+                                     const OnComplete& on_complete) {
+  return RunRecursiveLinearizationSearchImpl(
+      history_size, initial_state, adapter, on_complete);
+}
+
+template <class Hash, class Equal, class State, class Adapter>
+bool RunRecursiveLinearizationSearchWithCache(size_t history_size,
+                                              const State& initial_state,
+                                              const Adapter& adapter) {
+  return RunRecursiveLinearizationSearchWithCache<Hash, Equal>(
+      history_size, initial_state, adapter,
+      AcceptAnyCompletedLinearization<State>{});
+}
+
+template <class State, class Adapter>
+bool RunRecursiveLinearizationSearch(size_t history_size,
+                                     const State& initial_state,
+                                     const Adapter& adapter) {
+  return RunRecursiveLinearizationSearch(
+      history_size, initial_state, adapter,
+      AcceptAnyCompletedLinearization<State>{});
+}
+
+}  // namespace ltest::detail


### PR DESCRIPTION
Теперь есть общий рекурсивный поиск линеаризации из `LinearizabilityCheckerRecursive`.

- для поддержки дуальных структур данных нужен похожий поиск, но события в истории устроены сложнее: кроме обычных invoke/response дальше будут request/follow up.
- если оставить поиск внутри старого checker-а, то для дуальных историй пришлось бы почти полностью копировать тот же алгоритм.

Что сделано:
- добавлен файл `runtime/include/linearization_search.h` и в него вынесен общий backtracking-поиск по истории.
- добавлен кэш отрицательных состояний поиска для тех спецификаций, у которых есть hash/equal.

Как работает новый класс:
- поиск хранит, какие события истории уже линеаризованы.
- на каждом шаге выбирается минимальная операция, которую можно поставить следующей в последовательное объяснение.
- состояние спецификации копируется.
- через адаптер вызывается метод спецификации.
- если результат совпадает с response, операция помечается как линеаризованная.
- если такой путь не приводит к корректному объяснению, поиск откатывается и пробует другой порядок.
- если состояние уже проверялось и из него решения нет, оно не перебирается повторно.